### PR TITLE
Prevent HoneySpam to show up as start page in system configuration

### DIFF
--- a/app/code/community/Hackathon/HoneySpam/etc/system.xml
+++ b/app/code/community/Hackathon/HoneySpam/etc/system.xml
@@ -38,7 +38,7 @@
             <label>HoneySpam</label>
             <tab>hackathon</tab>
             <frontend_type>text</frontend_type>
-            <sort_order>10</sort_order>
+            <sort_order>100</sort_order>
             <show_in_default>1</show_in_default>
             <show_in_website>1</show_in_website>
             <show_in_store>1</show_in_store>


### PR DESCRIPTION
Sort order of sections influences which page shows up initially. 10 is too low and makes the honeyspam section appear as start page in most configurations.