### PR TITLE
Fix browser autocompletion

### DIFF
--- a/app/design/frontend/base/default/template/hackathon/honeyspam/honeypot.phtml
+++ b/app/design/frontend/base/default/template/hackathon/honeyspam/honeypot.phtml
@@ -27,4 +27,4 @@
 <?php
 /* @var $this Hackathon_HoneySpam_Block_Honeypot */
 ?>
-<input id="url" class="mhhs-input" type="text" name="<?php echo $this->getHoneypotName() ?>" />
+<input id="url" class="mhhs-input" type="text" name="<?php echo $this->getHoneypotName() ?>" autocomplete="off" autofill="off" />


### PR DESCRIPTION
Related to #31.

Added `autocomplete=off` and `autofill="off"` to honeypot input element.

Cheers!