### PR TITLE
XSS protection

### DIFF
--- a/app/code/community/Hackathon/HoneySpam/etc/system.xml
+++ b/app/code/community/Hackathon/HoneySpam/etc/system.xml
@@ -64,7 +64,8 @@
                         <honeypotName>
                             <label>Hidden field name</label>
                             <frontend_type>text</frontend_type>
-                            <sort_order>20</sort_order>
+                            <sort_order>20</sort_order> 
+                            <validate>validate-xml-identifier</validate>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
                             <show_in_store>1</show_in_store>

--- a/app/design/frontend/base/default/template/hackathon/honeyspam/honeypot.phtml
+++ b/app/design/frontend/base/default/template/hackathon/honeyspam/honeypot.phtml
@@ -27,4 +27,4 @@
 <?php
 /* @var $this Hackathon_HoneySpam_Block_Honeypot */
 ?>
-<input id="url" class="mhhs-input" type="text" name="<?php echo $this->getHoneypotName() ?>" autocomplete="off" autofill="off" />
+<input id="url" class="mhhs-input" type="text" name="<?php echo $this->quoteEscape($this->getHoneypotName()); ?>" autocomplete="off" autofill="off" />


### PR DESCRIPTION
Added protection against cross-site scripting (XSS) attacks targeting the honeypot field name setting pulled from the database.

See http://devdocs.magento.com/guides/v2.0/frontend-dev-guide/templates/template-security.html for guidance on escaping HTML attributes.