### PR TITLE
Fix Timestamp Check for custom Customer Create Forms

### DIFF
--- a/app/code/community/Hackathon/HoneySpam/Model/Observer.php
+++ b/app/code/community/Hackathon/HoneySpam/Model/Observer.php
@@ -124,9 +124,8 @@ class Hackathon_HoneySpam_Model_Observer
         $helper = Mage::helper('hackathon_honeyspam');
 
         $accountCreateTime = $helper->getHoneypotAccountCreateTime();
-        if (
-            !$session->getData('account_create_time', false)
-            || ($session->getData('account_create_time') > (time() - $accountCreateTime))
+        if ($session->getData('account_create_time', false)
+            && ($session->getData('account_create_time') > (time() - $accountCreateTime))
         ) {
             $helper->log('Honeypot Timestamp filled. Aborted.', Zend_Log::WARN);
 


### PR DESCRIPTION
If the customer create form is not placed in the `customer_account_create` handle, the session data `account_create_time` ist not set. This way each and every customer gets blocked.
My pull request changes the behavior of the timestamp check and only blocks customers, when  `account_create_time` is set and the create time was too short.
 