### PR TITLE
Add dependency to Mage_Captcha Extension

### DIFF
--- a/app/etc/modules/Hackathon_HoneySpam.xml
+++ b/app/etc/modules/Hackathon_HoneySpam.xml
@@ -29,6 +29,9 @@
         <Hackathon_HoneySpam>
             <active>true</active>
             <codePool>community</codePool>
+            <depends>
+                <Mage_Captcha />
+            </depends>
         </Hackathon_HoneySpam>
     </modules>
 </config>


### PR DESCRIPTION
This small PR suggests to make dependency to `Mage_Captcha` Extension explicit, as without this extension the layout handle `form.additional.info` is not available and therewith honeyspam won't work e.g. for customer forms. 